### PR TITLE
Fix eternal activity feed spinner for freshly created wallets

### DIFF
--- a/src/api/chains/solana/polling.ts
+++ b/src/api/chains/solana/polling.ts
@@ -194,6 +194,13 @@ function setupActivityPolling(
     throttledUpdate();
   }
 
+  // The balance stream skips uninitialized wallets (`ensureIsPollingNeeded`), so its updates -
+  // the only other trigger of `update()` - never fire for a fresh wallet. Without this initial
+  // load the chain never emits `initialActivities`, and the whole multi-chain feed waits for it.
+  if (newestConfirmedActivityTimestamp === undefined) {
+    update();
+  }
+
   return { update };
 }
 

--- a/src/components/main/sections/Content/Activities.tsx
+++ b/src/components/main/sections/Content/Activities.tsx
@@ -110,6 +110,7 @@ interface ItemPosition {
 }
 
 const FURTHER_SLICE = 30;
+const LOAD_RETRY_INTERVAL = 10000; // 10 sec
 
 const LIST_TOP_PADDING = 0.5; // rem
 const DATE_HEADER_HEIGHT = 2.125; // rem
@@ -261,10 +262,17 @@ function Activities({
 
   // Requests the history when the UI shows a spinner instead of the list.
   // Keeps requesting the history when all the currently loaded activities are hidden.
+  // Retries on an interval, because a failed request finishes silently with no state change -
+  // without a retry the spinner would stay forever (nothing else re-triggers the load).
   useEffect(() => {
-    if (!listItemIds?.length) {
-      loadMore();
+    if (listItemIds?.length) {
+      return undefined;
     }
+
+    loadMore();
+    const intervalId = window.setInterval(loadMore, LOAD_RETRY_INTERVAL);
+
+    return () => window.clearInterval(intervalId);
   }, [slug, allActivityIds, listItemIds, loadMore]);
 
   // Reset scroll and scroll tracking when the tab becomes inactive

--- a/src/components/main/sections/Content/Activities.tsx
+++ b/src/components/main/sections/Content/Activities.tsx
@@ -265,7 +265,7 @@ function Activities({
   // Retries on an interval, because a failed request finishes silently with no state change -
   // without a retry the spinner would stay forever (nothing else re-triggers the load).
   useEffect(() => {
-    if (listItemIds?.length) {
+    if (listItemIds?.length || isHistoryEndReached) {
       return undefined;
     }
 
@@ -273,7 +273,7 @@ function Activities({
     const intervalId = window.setInterval(loadMore, LOAD_RETRY_INTERVAL);
 
     return () => window.clearInterval(intervalId);
-  }, [slug, allActivityIds, listItemIds, loadMore]);
+  }, [slug, allActivityIds, listItemIds, isHistoryEndReached, loadMore]);
 
   // Reset scroll and scroll tracking when the tab becomes inactive
   useEffect(() => {

--- a/src/global/reducers/activities.test.ts
+++ b/src/global/reducers/activities.test.ts
@@ -105,6 +105,42 @@ describe('addInitialActivities', () => {
 
     expect(global.byAccountId[ACCOUNT_ID].activities?.idsMain).toEqual(['ton-1000']);
   });
+
+  it('recovers end-of-history when a failed chain later reports an empty history', () => {
+    // A failed initial load emits an empty update without `mainHistoryHasMore`. When the chain
+    // recovers and reports an empty history with `mainHistoryHasMore=false`, that update carries
+    // new information and must not be skipped - otherwise an empty wallet keeps the loading
+    // spinner forever instead of showing the empty state.
+    let global = buildGlobal();
+
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'ton', false);
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'solana', undefined);
+
+    expect(global.byAccountId[ACCOUNT_ID].activities?.idsMain).toEqual([]);
+    expect(global.byAccountId[ACCOUNT_ID].activities?.isMainHistoryEndReached).toBeUndefined();
+
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'solana', false);
+
+    expect(global.byAccountId[ACCOUNT_ID].activities?.isMainHistoryEndReached).toBe(true);
+  });
+
+  it('skips uninformative empty re-emits of an already loaded chain', () => {
+    let global = buildGlobal();
+
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'ton', false);
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'solana', false);
+
+    expect(global.byAccountId[ACCOUNT_ID].activities?.isMainHistoryEndReached).toBe(true);
+
+    const prevGlobal = global;
+    // A failed re-emit (no `mainHistoryHasMore`) must not degrade the reached state
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'solana', undefined);
+    expect(global).toBe(prevGlobal);
+
+    // A repeated successful empty emit carries no new information either
+    global = addInitialActivities(global, ACCOUNT_ID, [], {}, 'solana', false);
+    expect(global).toBe(prevGlobal);
+  });
 });
 
 describe('addPastActivities main feed', () => {

--- a/src/global/reducers/activities.ts
+++ b/src/global/reducers/activities.ts
@@ -48,10 +48,14 @@ export function addInitialActivities(
   // If the chain has already been marked as loaded and this update carries no data, skip the work
   // to avoid re-rendering on every retry of a persistently failing chain (per-chain pollings
   // emit empty `initialActivities` on each failed attempt to unblock `waitInitialActivityLoading`).
+  // Exception: an empty update that defines `mainHistoryHasMore` for the first time is a recovery
+  // after a failed attempt - it must be processed, otherwise `isMainHistoryEndReached` can never
+  // become true and an empty wallet keeps the loading spinner forever.
   if (
     areInitialActivitiesLoaded?.[chain]
     && mainActivities.length === 0
     && Object.keys(bySlug).length === 0
+    && (mainHistoryHasMore === undefined || mainHistoryHasMoreByChain?.[chain] !== undefined)
   ) {
     return global;
   }


### PR DESCRIPTION
У свежесозданного кошелька и субкошелька лента активности показывает вечный спиннер вместо экрана "You have just created a new wallet". Лента собирается только после того, как каждая сеть аккаунта отчитается первой загрузкой истории, а у Solana такая загрузка запускалась исключительно по сигналу баланс-стрима, который для неинициализированных адресов не стартует вовсе. Поэтому любой новый кошелек ждал 60-секундный таймаут и один страховочный запрос из UI: если тот проходил, спиннер жил полторы-две минуты, если падал, оставался навсегда, потому что повторов нет, а поздний успешный ответ восстановившейся сети редьюсер отбрасывал как пустой дубликат.

**Решение**
Solana загружает начальную историю сразу при старте поллинга, как остальные сети. Редьюсер перестал отбрасывать пустой ответ, который впервые сообщает, что истории больше нет. UI повторяет запрос истории раз в десять секунд, пока лента не загрузилась.
